### PR TITLE
Revert business contact, fix kekst spelling

### DIFF
--- a/src/en/index.vto
+++ b/src/en/index.vto
@@ -706,7 +706,7 @@ bodyclass: l-index
                 >JapanActivationCapital@kekstcnc.com</a>
               </p>
               <p class="p-index-contact__text p-index-contact__text--mt">
-                <span>Kskst CNC: Minako Otani / Andrew Mandel
+                <span>Kekst CNC: Minako Otani / Andrew Mandel
                 </span>
               </p>
             </div>

--- a/src/en/index.vto
+++ b/src/en/index.vto
@@ -690,8 +690,8 @@ bodyclass: l-index
                 For business inquiries, please contact
               </p>
               <p class="p-index-contact__text">
-                <a href="mailto:JapanActivationCapital@kekstcnc.com"
-                >JapanActivationCapital@kekstcnc.com</a>
+                <a href="mailto:contact@japanactivationcapital.com"
+                >contact@japanactivationcapital.com</a>
               </p>
             </div>
           </div>

--- a/src/index.vto
+++ b/src/index.vto
@@ -576,7 +576,7 @@ bodyclass: l-index
                 >JapanActivationCapital@kekstcnc.com</a>
               </p>
               <p class="p-index-contact__text p-index-contact__text--mt">
-                <span>担当者: Kskst CNC<br
+                <span>担当者: Kekst CNC<br
                     class="u-mobile"
                   />大谷みな子/アンドリュー・マンデル</span>
               </p>

--- a/src/index.vto
+++ b/src/index.vto
@@ -560,8 +560,8 @@ bodyclass: l-index
                 ビジネスに関するお問い合わせはこちら
               </p>
               <p class="p-index-contact__text">
-                <a href="mailto:JapanActivationCapital@kekstcnc.com"
-                >JapanActivationCapital@kekstcnc.com</a>
+                <a href="mailto:contact@japanactivationcapital.com"
+                >contact@japanactivationcapital.com</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
Inadvertently set business contact to the kekst address, so reverted it to contact@japanactivationcapital.com. ALso, spelling mistake corrected with kekst, which must have been that way from before.