### PR TITLE
Fix Mobile safari titles overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Get the first tag like this specifying the 0th element:
 <p class="p-entry-news__tag c-tag">{{ it.tags[0] }}</p>
 ```
 
-This works but it’s not elegant: 
+This works but it’s certainly not elegant: 
 
 ```
 <p class="p-entry-news__tag c-tag">{{ set firstKey = 0 }}{{ for key, item of it.tags }}{{ if key == firstKey }}{{ item }}{{ /if }}{{ /for }}</p>

--- a/src/team/cdo-三枝-幸夫_ja.yml
+++ b/src/team/cdo-三枝-幸夫_ja.yml
@@ -8,7 +8,7 @@ lang: ja
 id: bio_Saegusa
 weight: 610
 name: 三枝 幸夫
-position: <nobr>チーフ・<wbr>デジタル・<wbr>オフィサー</nobr>
+position: チーフ・<wbr>デジタル・<wbr>オフィサー
 team: Special Value Creation Team
 img: /media/SaegusaTHP_3559-3-square.jpg
 tags:

--- a/src/team/cfo-高橋-収_ja.yml
+++ b/src/team/cfo-高橋-収_ja.yml
@@ -8,7 +8,7 @@ lang: ja
 id: bio_TakahashiO
 weight: 600
 name: 髙橋 収
-position: <nobr>チーフ・<wbr>フィナンシャル・<wbr>オフィサー</nobr>
+position: チーフ・<wbr>フィナンシャル・<wbr>オフィサー
 team: Corporate Team
 img: /media/TakahashiOTHP_3391-3-square.jpg
 tags:

--- a/src/team/chro-西田-政之_ja.yml
+++ b/src/team/chro-西田-政之_ja.yml
@@ -10,7 +10,7 @@ lang: ja
 id: bio_nishida
 weight: 620
 name: 西田 政之
-position: <nobr>チーフ・<wbr>ヒューマンリソース・<wbr>オフィサー</nobr>
+position: チーフ・<wbr>ヒューマンリソース・<wbr>オフィサー
 team: Special Value Creation Team
 img: /media/nishidasq.jpg
 tags:

--- a/src/team/coo-佐竹-謙_ja.yml
+++ b/src/team/coo-佐竹-謙_ja.yml
@@ -12,7 +12,7 @@ lang: ja
 id: bio_Satake
 weight: 570
 name: 佐竹 謙
-position: <nobr>チーフ・<wbr>オペレーティング・<wbr>オフィサー</nobr>
+position: チーフ・<wbr>オペレーティング・<wbr>オフィサー
 team: Corporate Team
 img: /media/SatakeTHP_3333-3-square.jpg
 tags:

--- a/src/team/cso-磯貝-友紀_ja.yml
+++ b/src/team/cso-磯貝-友紀_ja.yml
@@ -11,7 +11,7 @@ lang: ja
 id: bio_isogai
 weight: 630
 name: 磯貝 友紀
-position: <nobr>チーフ・<wbr>サステナビリティ・<wbr>オフィサー</nobr>
+position: チーフ・<wbr>サステナビリティ・<wbr>オフィサー
 team: Special Value Creation Team
 img: /media/isogaig.jpg
 tags:

--- a/src/team/gc-cco-最上-健太郎_ja.yml
+++ b/src/team/gc-cco-最上-健太郎_ja.yml
@@ -13,7 +13,7 @@ lang: ja
 id: bio_Mogami
 weight: 580
 name: 最上 健太郎
-position: <nobr>ジェネラル・カウンセル兼<wbr>チーフ・ <wbr>コンプライアンス・ <wbr>オフィサー</nobr>
+position: ジェネラル・カウンセル兼<wbr>チーフ・ <wbr>コンプライアンス・ <wbr>オフィサー
 team: Corporate Team
 img: /media/MogamiTHP_3093-4-square.jpg
 tags:

--- a/src/team/md-大原-庸平_ja.yml
+++ b/src/team/md-大原-庸平_ja.yml
@@ -11,7 +11,7 @@ lang: ja
 id: bio_ohara
 weight: 635
 name: 大原 庸平
-position: <nobr>マネージング・<wbr>ディレクター</nobr>
+position: マネージング・<wbr>ディレクター
 team: CEO Office
 img: /media/ohara0731g.jpg
 tags:

--- a/src/team/md-酒向-麻子_ja.yml
+++ b/src/team/md-酒向-麻子_ja.yml
@@ -8,7 +8,7 @@ lang: ja
 id: bio_sakoh
 weight: 640
 name: 酒向 麻子
-position: <nobr>マネージング・<wbr>ディレクター</nobr>
+position: マネージング・<wbr>ディレクター
 team: Investor Relations Team
 img: /media/sakoh0730g.jpg
 tags:

--- a/src/team/インベストメントプロフェッショナル-小林-幸輝_ja.yml
+++ b/src/team/インベストメントプロフェッショナル-小林-幸輝_ja.yml
@@ -7,7 +7,7 @@ lang: ja
 id: bio_kobayashi
 weight: 677
 name: 小林 幸輝
-position: <nobr>インベストメント・<wbr>プロフェッショナル</nobr>
+position: インベストメント・<wbr>プロフェッショナル
 team: Investment Team
 img: /media/kobayashi2.jpg
 tags:

--- a/src/team/インベストメントプロフェッショナル-木下-紗希_ja.yml
+++ b/src/team/インベストメントプロフェッショナル-木下-紗希_ja.yml
@@ -7,7 +7,7 @@ lang: ja
 id: bio_Kinoshita
 weight: 670
 name: 木下 紗希
-position: <nobr>インベストメント・<wbr>プロフェッショナル</nobr>
+position: インベストメント・<wbr>プロフェッショナル
 team: Investment Team
 img: /media/kinoshitathp_3045-3.jpg
 tags:

--- a/src/team/インベストメントプロフェッショナル-森田-純_ja.yml
+++ b/src/team/インベストメントプロフェッショナル-森田-純_ja.yml
@@ -7,7 +7,7 @@ lang: ja
 id: bio_morita
 weight: 675
 name: 森田 純
-position: <nobr>インベストメント・<wbr>プロフェッショナル</nobr>
+position: インベストメント・<wbr>プロフェッショナル
 team: Investment Team
 img: /media/morita2.jpg
 tags:

--- a/src/team/オペレーティングエグゼクティブ-関-潤_ja.yml
+++ b/src/team/オペレーティングエグゼクティブ-関-潤_ja.yml
@@ -10,7 +10,7 @@ lang: ja
 id: bio_Seki
 weight: 1045
 name: 関 潤
-position: <nobr>オペレーティング・<wbr>エグゼクティブ</nobr>
+position: オペレーティング・<wbr>エグゼクティブ
 team: Advisors
 img: /media/seki1.jpg
 tags:

--- a/src/team/オペレーティングエグゼクティブ-高家-正行_ja.yml
+++ b/src/team/オペレーティングエグゼクティブ-高家-正行_ja.yml
@@ -9,7 +9,7 @@ lang: ja
 id: bio_Takaya
 weight: 1063
 name: 高家 正行
-position: <nobr>オペレーティング・<wbr>エグゼクティブ</nobr>
+position: オペレーティング・<wbr>エグゼクティブ
 team: Advisors
 img: /media/takaya1.jpg
 tags:

--- a/src/team/キャピタル・マーケッツ・スペシャリスト-松江-芳奈_ja.yml
+++ b/src/team/キャピタル・マーケッツ・スペシャリスト-松江-芳奈_ja.yml
@@ -9,7 +9,7 @@ lang: ja
 id: bio_Matsue
 weight: 680
 name: 松江 芳奈
-position: <nobr>キャピタル・<wbr>マーケッツ・<wbr>スペシャリスト</nobr>
+position: キャピタル・<wbr>マーケッツ・<wbr>スペシャリスト
 team: Investment Team
 img: /media/matsue0601gr.jpg
 tags:

--- a/src/team/シニアアドバイザー-丸山-寿_ja.yml
+++ b/src/team/シニアアドバイザー-丸山-寿_ja.yml
@@ -11,7 +11,7 @@ lang: ja
 id: bio_Maruyama
 weight: 1115
 name: 丸山 寿
-position: <nobr>シニア・<wbr>アドバイザー</nobr>
+position: シニア・<wbr>アドバイザー
 team: Advisors
 img: /media/maruyama.jpg
 tags:

--- a/src/team/シニアアドバイザー-小柴-満信_ja.yml
+++ b/src/team/シニアアドバイザー-小柴-満信_ja.yml
@@ -8,7 +8,7 @@ lang: ja
 id: bio_Koshiba
 weight: 1031
 name: 小柴 満信
-position: <nobr>シニア・<wbr>アドバイザー</nobr>
+position: シニア・<wbr>アドバイザー
 team: Advisors
 img: /media/koshibasq.jpg
 tags:

--- a/src/team/シニアアドバイザー-小泉-愼一_ja.yml
+++ b/src/team/シニアアドバイザー-小泉-愼一_ja.yml
@@ -12,7 +12,7 @@ lang: ja
 id: bio_Koizumi
 weight: 1029
 name: 小泉 愼一
-position: <nobr>シニア・<wbr>アドバイザー</nobr>
+position: シニア・<wbr>アドバイザー
 team: Advisors
 img: /media/koizumisq.jpg
 tags:

--- a/src/team/シニアアドバイザー-有沢-正人_ja.yml
+++ b/src/team/シニアアドバイザー-有沢-正人_ja.yml
@@ -7,7 +7,7 @@ lang: ja
 id: bio_arisawa
 weight: 1010
 name: 有沢 正人
-position: <nobr>シニア・<wbr>アドバイザー</nobr>
+position: シニア・<wbr>アドバイザー
 team: Advisors
 img: /media/arisawa1.jpg
 tags:

--- a/src/team/シニアアドバイザー-横田-乃里也_ja.yml
+++ b/src/team/シニアアドバイザー-横田-乃里也_ja.yml
@@ -12,7 +12,7 @@ lang: ja
 id: bio_Yokota
 weight: 1150
 name: 横田 乃里也
-position: <nobr>シニア・<wbr>アドバイザー</nobr>
+position: シニア・<wbr>アドバイザー
 team: Advisors
 img: /media/yokotasq.jpg
 tags:

--- a/src/team/シニアアドバイザー-河村-肇_ja.yml
+++ b/src/team/シニアアドバイザー-河村-肇_ja.yml
@@ -9,7 +9,7 @@ lang: ja
 id: bio_kawamura
 weight: 1023
 name: 河村 肇
-position: <nobr>シニア・<wbr>アドバイザー</nobr>
+position: シニア・<wbr>アドバイザー
 team: Advisors
 img: /media/kawamura1.jpg
 tags:

--- a/src/team/シニアアドバイザー-西尾-信也_ja.yml
+++ b/src/team/シニアアドバイザー-西尾-信也_ja.yml
@@ -8,7 +8,7 @@ lang: ja
 id: bio_nishio
 weight: 1085
 name: 西尾 信也
-position: <nobr>シニア・<wbr>アドバイザー</nobr>
+position: シニア・<wbr>アドバイザー
 team: Advisors
 img: /media/nishio4.jpg
 tags:

--- a/src/team/ヴァイス・プレジデント-佐伯-兼太郎_ja.yml
+++ b/src/team/ヴァイス・プレジデント-佐伯-兼太郎_ja.yml
@@ -10,7 +10,7 @@ lang: ja
 id: bio_Saeki
 weight: 655
 name: 佐伯 兼太郎
-position: <nobr>ヴァイス・<wbr>プレジデント</nobr>
+position: ヴァイス・<wbr>プレジデント
 team: Investment Team
 img: /media/saeki4.jpg
 tags:

--- a/src/team/ヴァイス・プレジデント-山本-克志_ja.yml
+++ b/src/team/ヴァイス・プレジデント-山本-克志_ja.yml
@@ -10,7 +10,7 @@ lang: ja
 id: bio_Yamamoto
 weight: 660
 name: 山本 克志
-position: <nobr>ヴァイス・<wbr>プレジデント</nobr>
+position: ヴァイス・<wbr>プレジデント
 team: Investment Team
 img: /media/yamamotothp_2967-2.jpg
 tags:

--- a/src/team/ヴァイス・プレジデント-谷口-絵理奈_ja.yml
+++ b/src/team/ヴァイス・プレジデント-谷口-絵理奈_ja.yml
@@ -10,7 +10,7 @@ lang: ja
 id: bio_taniguchi
 weight: 665
 name: 谷口 絵理奈
-position: <nobr>ヴァイス・プレジデント</nobr>
+position: ヴァイス・プレジデント
 team: Investor Relations Team
 img: /media/taniguchi-2.jpg
 tags:

--- a/src/team/髙橋-由紀子_ja.yml
+++ b/src/team/髙橋-由紀子_ja.yml
@@ -9,7 +9,7 @@ lang: ja
 id: bio_TakahashiY
 weight: 590
 name: 髙橋 由紀子
-position: <nobr>チーフ・<wbr>コントローラ</nobr>
+position: チーフ・<wbr>コントローラ
 team: Corporate Team
 img: /media/TakahashiYTHP_3669-3-square.jpg
 tags:


### PR DESCRIPTION
After adding wbr tags to titles in the bio pages, browser still did not break at appropriate places on safari. Turns out, the nobr tag we used before is deprecated and not honored on safari. Removed it, and now the /team page displays correctly. 