### PR TITLE
20241212-Fix-Team-Display

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -12,7 +12,7 @@
     ]
   },
   "imports": {
-    "lume/": "https://deno.land/x/lume@v2.4.2/",
+    "lume/": "https://deno.land/x/lume@v2.4.3/",
     "lume/cms/": "https://cdn.jsdelivr.net/gh/lumeland/cms@v0.7.2/"
   },
   "fmt": {

--- a/deno.lock
+++ b/deno.lock
@@ -2,6 +2,7 @@
   "version": "4",
   "specifiers": {
     "jsr:@davidbonnet/astring@1.8.6": "1.8.6",
+    "jsr:@libs/xml@6.0.3": "6.0.3",
     "jsr:@std/assert@0.224": "0.224.0",
     "jsr:@std/assert@0.226": "0.226.0",
     "jsr:@std/assert@~0.225.1": "0.225.3",
@@ -11,15 +12,18 @@
     "jsr:@std/cli@1.0.4": "1.0.4",
     "jsr:@std/cli@1.0.5": "1.0.5",
     "jsr:@std/cli@1.0.6": "1.0.6",
+    "jsr:@std/cli@1.0.8": "1.0.8",
     "jsr:@std/cli@^1.0.4": "1.0.4",
     "jsr:@std/cli@^1.0.5": "1.0.5",
     "jsr:@std/cli@^1.0.6": "1.0.6",
+    "jsr:@std/cli@^1.0.8": "1.0.8",
     "jsr:@std/cli@~0.224.5": "0.224.5",
     "jsr:@std/cli@~0.224.7": "0.224.7",
     "jsr:@std/collections@^1.0.0-rc.1": "1.0.2",
     "jsr:@std/collections@^1.0.2": "1.0.2",
     "jsr:@std/collections@^1.0.4": "1.0.4",
     "jsr:@std/collections@^1.0.5": "1.0.5",
+    "jsr:@std/collections@^1.0.9": "1.0.9",
     "jsr:@std/crypto@0.224.0": "0.224.0",
     "jsr:@std/crypto@1.0.0": "1.0.0",
     "jsr:@std/crypto@1.0.1": "1.0.1",
@@ -63,17 +67,21 @@
     "jsr:@std/fs@1.0.3": "1.0.3",
     "jsr:@std/fs@1.0.4": "1.0.4",
     "jsr:@std/fs@1.0.5": "1.0.5",
+    "jsr:@std/fs@1.0.6": "1.0.6",
     "jsr:@std/fs@^1.0.0-rc.1": "1.0.0-rc.1",
     "jsr:@std/fs@^1.0.0-rc.3": "1.0.0-rc.3",
     "jsr:@std/fs@^1.0.0-rc.5": "1.0.0-rc.5",
     "jsr:@std/fs@^1.0.2": "1.0.2",
     "jsr:@std/fs@^1.0.3": "1.0.3",
     "jsr:@std/fs@^1.0.4": "1.0.5",
+    "jsr:@std/fs@^1.0.6": "1.0.6",
     "jsr:@std/html@0.224.2": "0.224.2",
     "jsr:@std/html@1.0.0": "1.0.0",
     "jsr:@std/html@1.0.3": "1.0.3",
+    "jsr:@std/html@^1.0.3": "1.0.3",
     "jsr:@std/http@0.224.3": "0.224.3",
     "jsr:@std/http@0.224.5": "0.224.5",
+    "jsr:@std/http@1.0.12": "1.0.12",
     "jsr:@std/http@1.0.4": "1.0.4",
     "jsr:@std/http@1.0.5": "1.0.5",
     "jsr:@std/http@1.0.7": "1.0.7",
@@ -89,6 +97,7 @@
     "jsr:@std/jsonc@0.224.3": "0.224.3",
     "jsr:@std/jsonc@1.0.1": "1.0.1",
     "jsr:@std/log@0.224.1": "0.224.1",
+    "jsr:@std/log@0.224.11": "0.224.11",
     "jsr:@std/log@0.224.3": "0.224.3",
     "jsr:@std/log@0.224.4": "0.224.4",
     "jsr:@std/log@0.224.5": "0.224.5",
@@ -99,8 +108,10 @@
     "jsr:@std/media-types@0.224.1": "0.224.1",
     "jsr:@std/media-types@1.0.1": "1.0.1",
     "jsr:@std/media-types@1.0.3": "1.0.3",
+    "jsr:@std/media-types@1.1.0": "1.1.0",
     "jsr:@std/media-types@^1.0.0-rc.1": "1.0.1",
     "jsr:@std/media-types@^1.0.3": "1.0.3",
+    "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.1": "1.0.1",
     "jsr:@std/net@^1.0.2": "1.0.2",
     "jsr:@std/net@^1.0.4": "1.0.4",
@@ -118,19 +129,22 @@
     "jsr:@std/path@^1.0.4": "1.0.4",
     "jsr:@std/path@^1.0.6": "1.0.6",
     "jsr:@std/path@^1.0.7": "1.0.8",
+    "jsr:@std/path@^1.0.8": "1.0.8",
     "jsr:@std/path@~0.225.1": "0.225.2",
     "jsr:@std/path@~0.225.2": "0.225.2",
     "jsr:@std/streams@^1.0.3": "1.0.3",
     "jsr:@std/streams@^1.0.4": "1.0.4",
     "jsr:@std/streams@^1.0.6": "1.0.6",
     "jsr:@std/streams@^1.0.7": "1.0.8",
+    "jsr:@std/streams@^1.0.8": "1.0.8",
     "jsr:@std/streams@~0.224.3": "0.224.4",
     "jsr:@std/streams@~0.224.5": "0.224.5",
     "jsr:@std/toml@0.224.1": "0.224.1",
     "jsr:@std/toml@1.0.0": "1.0.0",
     "jsr:@std/toml@1.0.1": "1.0.1",
+    "jsr:@std/toml@1.0.2": "1.0.2",
     "jsr:@std/toml@^1.0.0-rc.3": "1.0.0",
-    "jsr:@std/toml@^1.0.1": "1.0.1",
+    "jsr:@std/toml@^1.0.1": "1.0.2",
     "jsr:@std/toml@~0.224.1": "0.224.1",
     "jsr:@std/yaml@0.224.1": "0.224.1",
     "jsr:@std/yaml@0.224.2": "0.224.2",
@@ -154,8 +168,10 @@
     "npm:lightningcss-wasm@1.26.0": "1.26.0",
     "npm:lightningcss-wasm@1.27.0": "1.27.0",
     "npm:lightningcss-wasm@1.28.1": "1.28.1",
+    "npm:lightningcss-wasm@1.28.2": "1.28.2",
     "npm:markdown-it-attrs@4.1.6": "4.1.6_markdown-it@14.1.0",
     "npm:markdown-it-attrs@4.2.0": "4.2.0_markdown-it@14.1.0",
+    "npm:markdown-it-attrs@4.3.0": "4.3.0_markdown-it@14.1.0",
     "npm:markdown-it-deflist@3.0.0": "3.0.0",
     "npm:markdown-it@14.1.0": "14.1.0",
     "npm:meriyah@4.4.2": "4.4.2",
@@ -166,6 +182,7 @@
     "npm:pagefind@1.2.0": "1.2.0",
     "npm:sass@1.79.4": "1.79.4",
     "npm:sass@1.80.6": "1.80.6",
+    "npm:sass@1.82.0": "1.82.0",
     "npm:sharp@0.33.4": "0.33.4",
     "npm:sharp@0.33.5": "0.33.5",
     "npm:svg2png-wasm@1.4.1": "1.4.1",
@@ -174,6 +191,9 @@
   "jsr": {
     "@davidbonnet/astring@1.8.6": {
       "integrity": "98b4914c8863cdf8c0ff83bb5c528caa67a8dca6020ad6234113499f00583e3a"
+    },
+    "@libs/xml@6.0.3": {
+      "integrity": "85506d5c61b0110d26dbb02059ce5a543226c3501fccbc7692e2ba4921f95567"
     },
     "@std/assert@0.224.0": {
       "integrity": "8643233ec7aec38a940a8264a6e3eed9bfa44e7a71cc6b3c8874213ff401967f"
@@ -202,6 +222,9 @@
     "@std/cli@1.0.6": {
       "integrity": "d22d8b38c66c666d7ad1f2a66c5b122da1704f985d3c47f01129f05abb6c5d3d"
     },
+    "@std/cli@1.0.8": {
+      "integrity": "3762d8dc9a373715c08d871c38d45e637b25266f013a1d0bbe560bca409de94e"
+    },
     "@std/collections@1.0.0-rc.1": {
       "integrity": "e69fa667e4bede8f1013be9fb48915e564707a2b054848ca4a4da1f3f10251d9"
     },
@@ -216,6 +239,9 @@
     },
     "@std/collections@1.0.5": {
       "integrity": "ab9eac23b57a0c0b89ba45134e61561f69f3d001f37235a248ed40be260c0c10"
+    },
+    "@std/collections@1.0.9": {
+      "integrity": "4f58104ead08a04a2199374247f07befe50ba01d9cca8cbb23ab9a0419921e71"
     },
     "@std/crypto@0.224.0": {
       "integrity": "154ef3ff08ef535562ef1a718718c5b2c5fc3808f0f9100daad69e829bfcdf2d",
@@ -362,6 +388,12 @@
         "jsr:@std/path@^1.0.7"
       ]
     },
+    "@std/fs@1.0.6": {
+      "integrity": "42b56e1e41b75583a21d5a37f6a6a27de9f510bcd36c0c85791d685ca0b85fa2",
+      "dependencies": [
+        "jsr:@std/path@^1.0.8"
+      ]
+    },
     "@std/html@0.224.2": {
       "integrity": "2f7bfd71081fad988af9ce991750ed1574917dc8e6fae0e151987ea020d1e21a"
     },
@@ -441,6 +473,19 @@
         "jsr:@std/net@^1.0.4",
         "jsr:@std/path@^1.0.7",
         "jsr:@std/streams@^1.0.7"
+      ]
+    },
+    "@std/http@1.0.12": {
+      "integrity": "85246d8bfe9c8e2538518725b158bdc31f616e0869255f4a8d9e3de919cab2aa",
+      "dependencies": [
+        "jsr:@std/cli@^1.0.8",
+        "jsr:@std/encoding@^1.0.5",
+        "jsr:@std/fmt@^1.0.3",
+        "jsr:@std/html@^1.0.3",
+        "jsr:@std/media-types@^1.1.0",
+        "jsr:@std/net@^1.0.4",
+        "jsr:@std/path@^1.0.8",
+        "jsr:@std/streams@^1.0.8"
       ]
     },
     "@std/io@0.224.1": {
@@ -541,6 +586,14 @@
         "jsr:@std/io@0.225"
       ]
     },
+    "@std/log@0.224.11": {
+      "integrity": "df5e5a6d6ab8bcea016a17982cd2435f65234d6618bf631925587c0b2eae2a4e",
+      "dependencies": [
+        "jsr:@std/fmt@^1.0.3",
+        "jsr:@std/fs@^1.0.6",
+        "jsr:@std/io@0.225"
+      ]
+    },
     "@std/media-types@0.224.1": {
       "integrity": "9e69a5daed37c5b5c6d3ce4731dc191f80e67f79bed392b0957d1d03b87f11e1"
     },
@@ -552,6 +605,9 @@
     },
     "@std/media-types@1.0.3": {
       "integrity": "b12d30a7852f7578f4d210622df713bbfd1cbdd9b4ec2eaf5c1845ab70bab159"
+    },
+    "@std/media-types@1.1.0": {
+      "integrity": "c9d093f0c05c3512932b330e3cc1fe1d627b301db33a4c2c2185c02471d6eaa4"
     },
     "@std/net@0.224.3": {
       "integrity": "a6257b9a35a4f299a0a9d4a4b76aef1f90ad05572374c5267c6c51a2ec41dfba"
@@ -635,6 +691,12 @@
       "integrity": "b55b407159930f338d384b1f8fd317c8e8a35e27ebb8946155f49e3a158d16c4",
       "dependencies": [
         "jsr:@std/collections@^1.0.5"
+      ]
+    },
+    "@std/toml@1.0.2": {
+      "integrity": "5892ba489c5b512265a384238a8fe8dddbbb9498b4b210ef1b9f0336a423a39b",
+      "dependencies": [
+        "jsr:@std/collections@^1.0.9"
       ]
     },
     "@std/yaml@0.224.1": {
@@ -1435,6 +1497,9 @@
     "immutable@4.3.7": {
       "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw=="
     },
+    "immutable@5.0.3": {
+      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw=="
+    },
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
@@ -1489,6 +1554,12 @@
         "napi-wasm"
       ]
     },
+    "lightningcss-wasm@1.28.2": {
+      "integrity": "sha512-g5aNMCathgTUunh8HWBIBDhnjM65hWZEEem6h2LoHU4nLiwGQLebXRnVV/HpavrnkvL1g7iYog4BURcq7YWKCA==",
+      "dependencies": [
+        "napi-wasm"
+      ]
+    },
     "linkify-it@5.0.0": {
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dependencies": [
@@ -1514,6 +1585,12 @@
     },
     "markdown-it-attrs@4.2.0_markdown-it@14.1.0": {
       "integrity": "sha512-m7svtUBythvcGFFZAv9VjMEvs8UbHri2sojJ3juJumoOzv8sdkx9a7W3KxiHbXxAbvL3Xauak8TMwCnvigVPKw==",
+      "dependencies": [
+        "markdown-it"
+      ]
+    },
+    "markdown-it-attrs@4.3.0_markdown-it@14.1.0": {
+      "integrity": "sha512-SQpN8q5LCYtRNuzHaWVLThuJmArN+H3b+jykwaK8AS8XlxyosRvge/7wT9N0XaXCJ5STHGl3gAc6/PXx37cbiQ==",
       "dependencies": [
         "markdown-it"
       ]
@@ -1736,7 +1813,7 @@
       "integrity": "sha512-K0QDSNPXgyqO4GZq2HO5Q70TLxTH6cIT59RdoCHMivrC8rqzaTw5ab9prjz9KUN1El4FLXrBXJhik61JR4HcGg==",
       "dependencies": [
         "chokidar",
-        "immutable",
+        "immutable@4.3.7",
         "source-map-js"
       ]
     },
@@ -1745,7 +1822,16 @@
       "dependencies": [
         "@parcel/watcher",
         "chokidar",
-        "immutable",
+        "immutable@4.3.7",
+        "source-map-js"
+      ]
+    },
+    "sass@1.82.0": {
+      "integrity": "sha512-j4GMCTa8elGyN9A7x7bEglx0VgSpNUG4W4wNedQ33wSMdnkqQCT8HTwOaVSV4e6yQovcu/3Oc4coJP/l0xhL2Q==",
+      "dependencies": [
+        "@parcel/watcher",
+        "chokidar",
+        "immutable@5.0.3",
         "source-map-js"
       ]
     },
@@ -3273,6 +3359,122 @@
     "https://deno.land/x/lume@v2.4.2/plugins/url.ts": "3718185697778f3b4dd17924d9d282d0a5a74030301e7fcae8a7f1b21f0ef9a9",
     "https://deno.land/x/lume@v2.4.2/plugins/vento.ts": "638ac1abe3086b43bc704ace0c99bb2c201c1e55418b84a73ef79d875344a44c",
     "https://deno.land/x/lume@v2.4.2/plugins/yaml.ts": "8cb20b4bf3a265be0d975235b537c9807db2f34d357fc27546c05d628d3fda9f",
+    "https://deno.land/x/lume@v2.4.3/cli.ts": "dcdc9d6abc1a219f1b972772ba27be33cebeffebb3db2d82a3f3d752d789a758",
+    "https://deno.land/x/lume@v2.4.3/cli/build.ts": "a3acda3c702d6a51a8fe65ea3abc17813deea0db71e442de6120a747f56a2466",
+    "https://deno.land/x/lume@v2.4.3/cli/build_worker.ts": "a96cb2f66e28a91e5e2e8c231b10942d03528eb6971ed6bf679828b223323dd6",
+    "https://deno.land/x/lume@v2.4.3/cli/cms.ts": "7f3f46c3353661a7679926d0ddcfe3e596f3c97ad2de7f535bde5906e42c3f5a",
+    "https://deno.land/x/lume@v2.4.3/cli/create.ts": "f340056e3b01a61007f82b47a174ede55df2d80d343e492a3853d44007bb8fc6",
+    "https://deno.land/x/lume@v2.4.3/cli/missing_worker_apis.ts": "70625ded7fee5de7d215e0829ce8dc4bb7060f6a496c09db880ebaec8b3efb92",
+    "https://deno.land/x/lume@v2.4.3/cli/run.ts": "27e7c84c2bcadc3aa4ca4fbad02330f33000dca9a2ef41780bad3676606bc029",
+    "https://deno.land/x/lume@v2.4.3/cli/upgrade.ts": "a11e7c9024f78c2e7376c57b4a99e389dbf490769779d2d37a4a3ccd6ef27d9e",
+    "https://deno.land/x/lume@v2.4.3/cli/utils.ts": "4697e4280ff62b537507ed707ec84ea707b0519f8de32e2e762f498104a8d1ae",
+    "https://deno.land/x/lume@v2.4.3/core/cache.ts": "e0d7f71e84bcc1c7f76d7ad35b9e9260a694215019f9c80763e17489b628f909",
+    "https://deno.land/x/lume@v2.4.3/core/component_loader.ts": "da80bf80a168d0b91b59eb3449fbf62627d8bf67879df34e71970616d47ce2ec",
+    "https://deno.land/x/lume@v2.4.3/core/data_loader.ts": "8698a9e9b1aac27147dc835ba89a0e30828c81338eceae86630607d78f146215",
+    "https://deno.land/x/lume@v2.4.3/core/events.ts": "e4fd1786eb7dd4a041d7d922779b9edf1ee89e51fd17ba5e756f380879ccb557",
+    "https://deno.land/x/lume@v2.4.3/core/file.ts": "27c04304793dec9972a24575ade217ace1eb204dd342d03930fd51fa5b8c2fbb",
+    "https://deno.land/x/lume@v2.4.3/core/formats.ts": "24d9f5ccf384b2474f457cc0d3855e6ad411ded0d6acf4afe36547ba93fc706f",
+    "https://deno.land/x/lume@v2.4.3/core/fs.ts": "0409ca756906a066300e8bdbad590a122aeffa4fa4192cd20b854c6f555bf00d",
+    "https://deno.land/x/lume@v2.4.3/core/loaders/binary.ts": "bb1e1cf3faac49f6007dc6814168dc0f633da17356db18e68862e4b2a87a3f33",
+    "https://deno.land/x/lume@v2.4.3/core/loaders/json.ts": "632e840340edf7d79091fb37474a1cbf86dd2d218090fb6f6c0420f5f5e9c2ce",
+    "https://deno.land/x/lume@v2.4.3/core/loaders/module.ts": "abcb210fa6724b83407407cd0f7ef90462b35a2017bc135a3d124dd7f38843f6",
+    "https://deno.land/x/lume@v2.4.3/core/loaders/text.ts": "42860fc3482651fa6cfba18a734bb548d6e6e1163bf1015c2abc447ab150acbd",
+    "https://deno.land/x/lume@v2.4.3/core/loaders/toml.ts": "72ddfef2deea62815c28e27faa2c5356e09b3109e9547e47a6defea3d3332452",
+    "https://deno.land/x/lume@v2.4.3/core/loaders/yaml.ts": "241dc41fbe51b92e38dc748eda614c35d80fb8c63a6d40253453c6bb78c9c47e",
+    "https://deno.land/x/lume@v2.4.3/core/processors.ts": "ce9b97307740723afd86d1773e946981a96769189ba6acd649b412e48552045d",
+    "https://deno.land/x/lume@v2.4.3/core/renderer.ts": "b1879895f7544326e61e95a6413689975e79eabae0c48ca5912f06d2b4afde43",
+    "https://deno.land/x/lume@v2.4.3/core/scopes.ts": "dbdf93d7a9cead84833779e974f190b1379356ec7c0ccd34aa92f917c2cdd2f9",
+    "https://deno.land/x/lume@v2.4.3/core/scripts.ts": "286969b120d2290ba57a7fdd9b37e587aacf4e4162d92f51f1f1e9e18c864f30",
+    "https://deno.land/x/lume@v2.4.3/core/searcher.ts": "9093c2c64d1190b55a886b2905a224e0cbf86532bea4883e065e391851a8f14c",
+    "https://deno.land/x/lume@v2.4.3/core/server.ts": "33b947e2be6a81f7673e5c87966da63d6ce1fc0f120b2246f048910ed2397d08",
+    "https://deno.land/x/lume@v2.4.3/core/site.ts": "663f20d7e1113dec63e595044b7df69b154ca1897333a34266d3b968b1274dfe",
+    "https://deno.land/x/lume@v2.4.3/core/source.ts": "1a5bc2c5fe89e7acbafcc38c4b72de8f609064b9ecf454472fadfe6f44d3dd4d",
+    "https://deno.land/x/lume@v2.4.3/core/utils/cli_options.ts": "9cf76ff7ee5206281cd2f06c6d9e5bdffb33e6df5ba0fc95fd249b5e27d47202",
+    "https://deno.land/x/lume@v2.4.3/core/utils/concurrent.ts": "cb0775b3d95f3faa356aa3a3e489dccef8807ed93cc4f84fcf5bc81e87c29504",
+    "https://deno.land/x/lume@v2.4.3/core/utils/data_values.ts": "1923c211b4cdab6bf17353b21319655060357a17bffe3f8743639cf22124a746",
+    "https://deno.land/x/lume@v2.4.3/core/utils/date.ts": "4972e6e43d9756a3858494004e1b45df3b947033abe68db02acfc0bbb7847ce1",
+    "https://deno.land/x/lume@v2.4.3/core/utils/digest.ts": "445b387983391af73269686292a65bb677119a25a327776885ff1242a9397ad8",
+    "https://deno.land/x/lume@v2.4.3/core/utils/dom.ts": "d406fb5c48ceb012286d0aff66ef635261eda666de2ce07538c0cf9366b8fecd",
+    "https://deno.land/x/lume@v2.4.3/core/utils/env.ts": "d2440f14ad27e65b0a42b35a52f59ccce0430dd52950bd5df103bb1c9ba1a4a7",
+    "https://deno.land/x/lume@v2.4.3/core/utils/generator.ts": "1e664e9fd4c469e38a0acf5c94fd49dac4f38cb6334563ea4b7fc498b5958877",
+    "https://deno.land/x/lume@v2.4.3/core/utils/log.ts": "9b229e345d85ce8bd2d108bff99c8c57fcbded62e65776af294f94f349b48641",
+    "https://deno.land/x/lume@v2.4.3/core/utils/lume_config.ts": "1dd321aea867cbd5e744c6a81f82cd6caf4095ba93cabd03c667368be19494ba",
+    "https://deno.land/x/lume@v2.4.3/core/utils/lume_version.ts": "96ce8c0144b5adbc170f388b60be706244d1bd100413e748e9cf23878838c87c",
+    "https://deno.land/x/lume@v2.4.3/core/utils/merge_data.ts": "a574d97eeaa1513d30440488f52e988f0fe2085397611852673cea10076f01ff",
+    "https://deno.land/x/lume@v2.4.3/core/utils/net.ts": "982f86aa708272642f65a9086f2af2553cfedcd9f55bc675dce5c44bdc91e208",
+    "https://deno.land/x/lume@v2.4.3/core/utils/object.ts": "e00ee6e91264064772c87e69e128a09ba0e30c2c41be4a5302881f59f456fc31",
+    "https://deno.land/x/lume@v2.4.3/core/utils/page_content.ts": "e7d4323a7b66d1ae26c1263dd5a13a0c5e9f73583c9cf83454ad61f157d8351d",
+    "https://deno.land/x/lume@v2.4.3/core/utils/page_date.ts": "2a3d9c203df298ca61f568fdf509945f127f990769623c3edfd753d39807b757",
+    "https://deno.land/x/lume@v2.4.3/core/utils/page_url.ts": "8d672d6e292a50952727dda75edd70d7ec98d793de569b24e1f90a35e7836b16",
+    "https://deno.land/x/lume@v2.4.3/core/utils/path.ts": "109b9a6c450929db4f7b133859f5eebbe92999d3cc523a19988a058abec582b5",
+    "https://deno.land/x/lume@v2.4.3/core/utils/read.ts": "e096b1f37f8f0a6820e6ee00af1832d133598d55c961b226d057a5467207c5cd",
+    "https://deno.land/x/lume@v2.4.3/core/watcher.ts": "6c6c4b5feb540958bfd3ca78f420f4278d39eb317e9476aeec85d0ca69368873",
+    "https://deno.land/x/lume@v2.4.3/core/writer.ts": "7c56cdae2fcbaebe3c4d66d6c75bc056906d82517d880ba8e02acbb464e6c6b6",
+    "https://deno.land/x/lume@v2.4.3/deps/base64.ts": "2d304cd4c71af8fa74d4ab5d204a3ac862d21d4b06af66af173276c759fe6271",
+    "https://deno.land/x/lume@v2.4.3/deps/brotli.ts": "7500a8ea7474fa73fae329b00974379de587b4fcdcc68449097e6504c49f19a1",
+    "https://deno.land/x/lume@v2.4.3/deps/cli.ts": "141bf06ea76e797ee1eaa73d5d944c70c21e22aaf0963cd407bb8ae23eb58647",
+    "https://deno.land/x/lume@v2.4.3/deps/cliffy.ts": "faff0c2ca187ec9fd1ad8660141f85b9d05b5c36bab25b40eb5038c02590a310",
+    "https://deno.land/x/lume@v2.4.3/deps/colors.ts": "8642f31364e8d1b7c3bba56cfee21f8abdd545b5e1c8350cfcc104531eca164c",
+    "https://deno.land/x/lume@v2.4.3/deps/crypto.ts": "020df39e6ba16ec8f3936b0ceff03a3d64bde8900a976ba3a519b5cc09d337d2",
+    "https://deno.land/x/lume@v2.4.3/deps/date.ts": "cbd4703210520fafd80daf364d9aa4180b322e88f6d01269f6002cfd10a33109",
+    "https://deno.land/x/lume@v2.4.3/deps/decap.ts": "1ff29a48b6d8c6b2f2bf0dafe118f675e331972f7cd236c3569c4d95c79976e5",
+    "https://deno.land/x/lume@v2.4.3/deps/dom.ts": "5670c225863738487fb03d19524dfcdd6d08c8851ffc9435d7142806cea6a458",
+    "https://deno.land/x/lume@v2.4.3/deps/front_matter.ts": "279c53db46ac7f557f217ffb7fbd0c307ad6cbd8ff64d91cd8b023a3b50b2c92",
+    "https://deno.land/x/lume@v2.4.3/deps/fs.ts": "a98e5f8af8e96fff8e9b039c2ead887ba25b80844dfa62a63537fff77aa374fd",
+    "https://deno.land/x/lume@v2.4.3/deps/hex.ts": "345dabf92ede0e4b1aed5b6d831099bcf62ec0f75d45519e42194ee527f7c8b9",
+    "https://deno.land/x/lume@v2.4.3/deps/http.ts": "499d1e2f89bad31d06adb3d6a76207b7fc81b3fb91f274d46ca9ae2464fed97d",
+    "https://deno.land/x/lume@v2.4.3/deps/init.ts": "05d45af66ebdfe63e43540618f51ece8f99d98dc49de890f10eeb43abe9ed0f3",
+    "https://deno.land/x/lume@v2.4.3/deps/jsonc.ts": "e359eb0ef9f5f15518e6afe9bafb5b48bd5798dc000c8e210953c29cb319e607",
+    "https://deno.land/x/lume@v2.4.3/deps/lightningcss.ts": "27d03bfaf48fb86467b4ac3a73215ea63e69357e80104c3e2b44ca10b6518412",
+    "https://deno.land/x/lume@v2.4.3/deps/log.ts": "a5fbeee6eaaf4e8d9fe3e14d22634e5d67c5290fb4d41c24f458b93f196199f7",
+    "https://deno.land/x/lume@v2.4.3/deps/markdown_it.ts": "dc5e0b4026a96ce3991e32011562eebb12bc46f9d062c0edfae0c79013a5ece6",
+    "https://deno.land/x/lume@v2.4.3/deps/media_types.ts": "fab5c276f8abd1db34ed7c5ccdc3d88f7a1a075cc1d1156919cab0ef35587afc",
+    "https://deno.land/x/lume@v2.4.3/deps/minify_html.ts": "d6b88e9bcbcef9d0658916f852e6f9322ed88622368b01da4477533b66c11591",
+    "https://deno.land/x/lume@v2.4.3/deps/pagefind.ts": "1127dc93be9a4c4de9cf84c18f6525359a0004e7dd9b220cd30faefe55202c60",
+    "https://deno.land/x/lume@v2.4.3/deps/path.ts": "2cb9b457032c687de61df71a5855a97d7de18386bfe3048c03377c733e96b3ab",
+    "https://deno.land/x/lume@v2.4.3/deps/sass.ts": "b6b5336d98fad45bbf48c082183ac06affe44cb025494382f94c2f47b1bad45e",
+    "https://deno.land/x/lume@v2.4.3/deps/sharp.ts": "67d02a65eda73fc23cc76220c95a832ccbc842bdb7eab205761da27352c38aae",
+    "https://deno.land/x/lume@v2.4.3/deps/svg2png.ts": "d761fb39c37e5c5ba4ac2db25768cf0c2ff34643d3d1847a9fe736449175d5ec",
+    "https://deno.land/x/lume@v2.4.3/deps/svgo.ts": "688d1272b1a2113d8ad35e70854a189d6c238b04b8237529acdaa8028abc40d6",
+    "https://deno.land/x/lume@v2.4.3/deps/temporal.ts": "1958b134c4186b0ab39316fa33ba19d1a4203e2ea445080429d60d296b91a552",
+    "https://deno.land/x/lume@v2.4.3/deps/toml.ts": "cc55b94f0c44e4113ff09e153e8b1c58bc5f585b7ea1e8f14f96c8152241b166",
+    "https://deno.land/x/lume@v2.4.3/deps/vento.ts": "1e22bca1ec8b080a00b03fae32d210a453bc0519107ca5670a492b10dac65e7d",
+    "https://deno.land/x/lume@v2.4.3/deps/xml.ts": "b5663194248d7d18806a7cf801958fcf5e72ff22160a3193cea06b6e98e66b0a",
+    "https://deno.land/x/lume@v2.4.3/deps/yaml.ts": "cbcf4d295ed88066e12a718750f09cebbf30fefa32e186844b597bce74b35557",
+    "https://deno.land/x/lume@v2.4.3/middlewares/logger.ts": "c96f1a9f9d5757555b6f141865ce8551ac176f90c8ee3e9ad797b2b400a9a567",
+    "https://deno.land/x/lume@v2.4.3/middlewares/no_cache.ts": "0119e3ae3a596ab12c42df693b93e5b03dd9608e289d862242751a9739438f35",
+    "https://deno.land/x/lume@v2.4.3/middlewares/no_cors.ts": "4d24619b5373c98bcc3baf404db47ba088c87ac8538ea1784e58d197b81d4d02",
+    "https://deno.land/x/lume@v2.4.3/middlewares/not_found.ts": "4507842d422267062c34662dceab17affcaad01858a5890fda163a8ddeb31487",
+    "https://deno.land/x/lume@v2.4.3/middlewares/reload.ts": "ec723e917bd12c83f65fc39a66592add9ec2ab56a1ad17f429ba749d32c218f9",
+    "https://deno.land/x/lume@v2.4.3/middlewares/reload_client.js": "992ac4a2f4a9fb4a1ab5f23f674ef202a43d73652cdebcf7b1552b482a7410ef",
+    "https://deno.land/x/lume@v2.4.3/mod.ts": "f93dcbc0ccb7a9e6cab93d0e8f1f0643b112f3084bedc603379dc1b47d7d380d",
+    "https://deno.land/x/lume@v2.4.3/plugins/brotli.ts": "eae2e4c959bfa0d1e8d8cd43504269ed08a2b0597b6de229b57ca5c4afb5b4a7",
+    "https://deno.land/x/lume@v2.4.3/plugins/date.ts": "d92823f67326e4f5d73d8cda2e357d36c07a30f4824d95b9402ae4202b336e0c",
+    "https://deno.land/x/lume@v2.4.3/plugins/decap_cms.ts": "59580f23596a550e80e275b5c728a7612c25217cfe7a202bd5239c96910bb1a8",
+    "https://deno.land/x/lume@v2.4.3/plugins/favicon.ts": "5822264902eb1ab06d9b5c56767ac2997f40c31eba66983b083d02af2d7244e5",
+    "https://deno.land/x/lume@v2.4.3/plugins/filter_pages.ts": "d9c5f62f34dc0bb9e8e22b543903605237140e9e23d342dc61ee48d32d0b3f09",
+    "https://deno.land/x/lume@v2.4.3/plugins/google_fonts.ts": "d9bc4de6f0ff8df132555a77bed1dfff9cb72088055f3644cad2bd14a7430921",
+    "https://deno.land/x/lume@v2.4.3/plugins/json.ts": "67e5e2e00f8e8640f33c1f97a2bf82a7c97a67a838804637b87b16b72f9042e1",
+    "https://deno.land/x/lume@v2.4.3/plugins/lightningcss.ts": "d8a4b4355375567b78f5e298dba243a70c94614314679d9592eb4287c709a449",
+    "https://deno.land/x/lume@v2.4.3/plugins/markdown.ts": "c7027605edee274762edb20f7040ccba6415c5fe656cc6e25ce91c448f467fd8",
+    "https://deno.land/x/lume@v2.4.3/plugins/metas.ts": "85696cb0422a62a3958098ff608f5878014aa62f7c5fc52ef7ccf14a5df5cf6f",
+    "https://deno.land/x/lume@v2.4.3/plugins/minify_html.ts": "521bdd0e00c2bb9bb486818f8909616945aaf11f127a67a3d11687d9893294d0",
+    "https://deno.land/x/lume@v2.4.3/plugins/modules.ts": "e64197315d930e462aca24e444d0cfcefb37bfea168b2306122b892a1e1c5b8e",
+    "https://deno.land/x/lume@v2.4.3/plugins/multilanguage.ts": "f6a000d1df368c9bbba976fbd3ef91a3dd170399603086390d7f35fcb8cf59fa",
+    "https://deno.land/x/lume@v2.4.3/plugins/pagefind.ts": "62b112506555ca1eb77b933e289d8f06cd623ace1ae0306a7070964dd5455ea7",
+    "https://deno.land/x/lume@v2.4.3/plugins/paginate.ts": "7dfee977a205dfe0af33a3e406f73017badd2d4593cf27e5bd897da7ab12ba8a",
+    "https://deno.land/x/lume@v2.4.3/plugins/picture.ts": "51c353193e0d2b4f9f3d3e64177216d4e0605a9e572e1bd1378f725710c627f3",
+    "https://deno.land/x/lume@v2.4.3/plugins/robots.ts": "154607ea9976b8c4dbbfb8791bdb2a65c5e9540073fcca03d80642582f16fba5",
+    "https://deno.land/x/lume@v2.4.3/plugins/sass.ts": "099b3814385def43de0e742543f80275f1c6d3adf92643d0b6bd8d2cd627e07a",
+    "https://deno.land/x/lume@v2.4.3/plugins/search.ts": "ff570560c6ca95598a1cbfb3a77611477ee7dbb53300bcc3ba14d18c9e5eba79",
+    "https://deno.land/x/lume@v2.4.3/plugins/sitemap.ts": "a8f7ce33eb4b5fe480d170bb0b69bc219f5a8612ea31ca5b8643d68a3e5531ad",
+    "https://deno.land/x/lume@v2.4.3/plugins/source_maps.ts": "6260905d95155c1fd44eb221a8dee096c6c13052899477bd84e8e180d3a740b3",
+    "https://deno.land/x/lume@v2.4.3/plugins/svgo.ts": "f63a913294f753ad7e3bfaae571577590da767828c8d744a3650ca1f746d1221",
+    "https://deno.land/x/lume@v2.4.3/plugins/toml.ts": "72c75546056e503a59752e33dc25542f2aa21d743bd47f498d722b97958212f5",
+    "https://deno.land/x/lume@v2.4.3/plugins/transform_images.ts": "0bc90e12326f60363707180a944f1e435fd46171b2122f79d52ec147d0e6bd5b",
+    "https://deno.land/x/lume@v2.4.3/plugins/url.ts": "3718185697778f3b4dd17924d9d282d0a5a74030301e7fcae8a7f1b21f0ef9a9",
+    "https://deno.land/x/lume@v2.4.3/plugins/vento.ts": "638ac1abe3086b43bc704ace0c99bb2c201c1e55418b84a73ef79d875344a44c",
+    "https://deno.land/x/lume@v2.4.3/plugins/yaml.ts": "8cb20b4bf3a265be0d975235b537c9807db2f34d357fc27546c05d628d3fda9f",
     "https://deno.land/x/lume_init@v0.2.4/deps.ts": "63615f5a253b18494560df31158a13508869dd53eff9f58155dd965d8e01245a",
     "https://deno.land/x/lume_init@v0.2.4/init.ts": "73c671cb71e7ba82dd47813752272f6cd4b1c4511420bd36ee876bb483b12248",
     "https://deno.land/x/lume_init@v0.2.4/mod.ts": "8f02778efdcc5e59218acdefa1c7bb9bb5032d7d0041f480555c1b184fdeeccf",
@@ -3421,6 +3623,27 @@
     "https://deno.land/x/vento@v1.12.11/src/loader.ts": "c05add67f582e937ee611852075ce2cc038b5e80e3e609eef96fa5ed74a5086c",
     "https://deno.land/x/vento@v1.12.11/src/tokenizer.ts": "127ddad02054f63b8b646e4dfbf555e1e34e9b8dcbd58d86b3729a4de95abd27",
     "https://deno.land/x/vento@v1.12.11/src/transformer.ts": "587a0b107a2bd1437a3093c4c44c07e4fdf3abfaaf8e845767b69bd34a039154",
+    "https://deno.land/x/vento@v1.12.13/deps.ts": "47ad104c87a32292e978f0fba4f69954f7feff3b403833858e1cc51c5313e9db",
+    "https://deno.land/x/vento@v1.12.13/mod.ts": "cfaac455f70af8e59aa0c03ef39b641635094225255f0fbaa76f4771e683f2ca",
+    "https://deno.land/x/vento@v1.12.13/plugins/echo.ts": "59adb9137e736029cf18e3d95e010803c8728046d0d040702c16c4930c7b6160",
+    "https://deno.land/x/vento@v1.12.13/plugins/escape.ts": "22754819f9a8437ecb4de0df1d3513c5b92fd6be74274d344d9750811030b181",
+    "https://deno.land/x/vento@v1.12.13/plugins/export.ts": "4cda1bd2d7e28e6d23382a64a6d72e7340bef07fcbc32f604a4705c148b914f1",
+    "https://deno.land/x/vento@v1.12.13/plugins/for.ts": "7eabf1f5f4b52aa3cccafcdfcbbd808628e386b90e61527adbcf1f23e4ab1777",
+    "https://deno.land/x/vento@v1.12.13/plugins/function.ts": "24c33bf586844ff8940daac2535dcae7f5ce39b443e795ebf16a2c23694850bf",
+    "https://deno.land/x/vento@v1.12.13/plugins/if.ts": "f992b1f599be11eafaa15bf607eee467ffd4276dec145d7b73cd24c0c6920631",
+    "https://deno.land/x/vento@v1.12.13/plugins/import.ts": "c36710067e1ea4074097b139c95d001fc1a2e759e05f1346da068405657924b4",
+    "https://deno.land/x/vento@v1.12.13/plugins/include.ts": "d93d330d3df25a5cfcc34e85c3e6685214280792f3242064e50c94748acfb1f4",
+    "https://deno.land/x/vento@v1.12.13/plugins/js.ts": "68d78ef2fc7a981d1f124f2f91830135ad46fcbd4dde7d5464cb5103c9293a5e",
+    "https://deno.land/x/vento@v1.12.13/plugins/layout.ts": "da84978f0639e95e472edddc2f9837757c28113a04dbe67399087c3a4d14780e",
+    "https://deno.land/x/vento@v1.12.13/plugins/set.ts": "0938601748ab7cc5ca3bb80c97e041183ef90fd3d9819dc7546ce9079b717a6d",
+    "https://deno.land/x/vento@v1.12.13/plugins/trim.ts": "93bce5e32aac9fd1dc4e7acf0278438d710cd1f61f80ce3af719a06cca7f2e3d",
+    "https://deno.land/x/vento@v1.12.13/plugins/unescape.ts": "dd2d9dbd116b68004f11ab17c9daaf9378ee14300c2d0ec8f422df09d41462ba",
+    "https://deno.land/x/vento@v1.12.13/src/environment.ts": "34ca5c981d0a54a678d421cd80a14aeb7974a8126944782048cb26348469c3d0",
+    "https://deno.land/x/vento@v1.12.13/src/errors.ts": "d96e63c3b33f0daf6ee36dd87b4b09fc09e5ac214464cab4e2534881978fd9a1",
+    "https://deno.land/x/vento@v1.12.13/src/js.ts": "c4ac5e2b2cd2995523d3167c5708c424686fd30d2d3951ff965a76dbdfb74e37",
+    "https://deno.land/x/vento@v1.12.13/src/loader.ts": "c05add67f582e937ee611852075ce2cc038b5e80e3e609eef96fa5ed74a5086c",
+    "https://deno.land/x/vento@v1.12.13/src/tokenizer.ts": "127ddad02054f63b8b646e4dfbf555e1e34e9b8dcbd58d86b3729a4de95abd27",
+    "https://deno.land/x/vento@v1.12.13/src/transformer.ts": "1dd0fb9c2a14bc8384b2dc557ab1131b2f9728cdbe1c47ac35bc3bd3b0ba4d47",
     "https://deno.land/x/xml@5.4.12/mod.ts": "b59e5c0dd9fe7ed597c21c39aacf089aa82fe5c5eaad3f411a43a9c104359f4e",
     "https://deno.land/x/xml@5.4.12/parse.ts": "af704c72d42607d5b3f364972c413e05b6d2921d164806ec47aee348cf6ce49c",
     "https://deno.land/x/xml@5.4.12/stringify.ts": "a00881a1e563902538cfea8ce31464c81e98e61dddcf718039d7118b46464687",

--- a/src/_data/decap_cms.yml
+++ b/src/_data/decap_cms.yml
@@ -154,10 +154,10 @@ collections:
         name: position
         widget: string
         hint: Enter the person’s job title, in the same language as the content.
-      - label: Short Introduction
-        name: short
+      - label: Bio Page Team
+        name: team
         widget: text
-        hint: Enter a short biographical sentence about the person.
+        hint: Enter team name, confirming and being consistent with other members of the team.
       - label: Image
         name: img
         widget: image

--- a/src/team/hisashi-maruyama-senior-advisor_en.yml
+++ b/src/team/hisashi-maruyama-senior-advisor_en.yml
@@ -13,7 +13,7 @@ id: bio_Maruyama
 weight: 1044
 name: Hisashi Maruyama
 position: Senior Advisor
-short: " "
+team: Advisors
 img: /media/maruyama.jpg
 tags:
   - Advisor
@@ -27,4 +27,3 @@ bio: >-
   \
 
   Mr. Maruyama currently serves as an Independent Director of Zensho Holdings and Yokogawa Electric Corporation.
-team: Advisors

--- a/src/team/suguru-matsufuji-vice-president_en.yml
+++ b/src/team/suguru-matsufuji-vice-president_en.yml
@@ -13,7 +13,6 @@ id: bio_Matsufuji
 weight: 605
 name: Suguru Matsufuji
 position: Vice President
-short: " "
 team: Corporate Team
 img: /media/matsufuji.jpg
 tags:

--- a/src/team/suguru-matsufuji-vice-president_en.yml
+++ b/src/team/suguru-matsufuji-vice-president_en.yml
@@ -14,6 +14,7 @@ weight: 605
 name: Suguru Matsufuji
 position: Vice President
 short: " "
+team: Corporate Team
 img: /media/matsufuji.jpg
 tags:
   - Corporate
@@ -31,4 +32,3 @@ bio: >-
   \
 
   Mr. Matsufuji holds a B.A in Economics from The University of Tokyo, and is a US Certified Public Accountant (Washington state).
-team: Investment Team

--- a/src/team/ヴァイスプレジデント-松藤-卓_ja.yml
+++ b/src/team/ヴァイスプレジデント-松藤-卓_ja.yml
@@ -11,6 +11,7 @@ weight: 605
 name: 松藤 卓
 position: ヴァイス・<wbr>プレジデント
 short: " "
+team: Corporate Team
 img: /media/matsufuji.jpg
 tags:
   - Corporate
@@ -20,4 +21,3 @@ bio: |-
   それ以前は、東京短資に勤務。日本国債レポ市場においてブローカー業務に従事する傍ら、取引先向けの市況レポートを執筆。\
   \
   学歴：東京大学経済学部経済学科卒 米国公認会計士（ワシントン州）
-team: Corporate Team

--- a/src/team/ヴァイスプレジデント-松藤-卓_ja.yml
+++ b/src/team/ヴァイスプレジデント-松藤-卓_ja.yml
@@ -10,7 +10,6 @@ id: bio_Matsufuji
 weight: 605
 name: 松藤 卓
 position: ヴァイス・<wbr>プレジデント
-short: " "
 team: Corporate Team
 img: /media/matsufuji.jpg
 tags:


### PR DESCRIPTION
Fixed bio page "Team" display. Removed "short" field from all bios and from decapCMS's UI. Confirmed "team" field exists and that all bio's are set correctly. Upgraded SSG Lume to 2.4.3, and underlying Deno to 2.1.4.