### PR TITLE
Lint fundamental problems in Bone's js

### DIFF
--- a/src/assets/js/index.js
+++ b/src/assets/js/index.js
@@ -5,7 +5,7 @@ document.addEventListener("DOMContentLoaded", function () {
   const secondSection = document.querySelector("[data-second-section]");
   const followingHeader = document.querySelector("[data-following-header]");
 
-  window.addEventListener("scroll", () => {
+  globalThis.addEventListener("scroll", () => {
     const sectionRect = secondSection.getBoundingClientRect();
 
     if (sectionRect.top <= 0) {
@@ -26,7 +26,7 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   getMvHeight();
-  window.addEventListener("resize", getMvHeight);
+  globalThis.addEventListener("resize", getMvHeight);
 });
 
 // スライダー
@@ -82,7 +82,7 @@ for (const item of items) {
 }
 
 // スクロールアニメーション
-window.addEventListener("load", () => {
+globalThis.addEventListener("load", () => {
   const scrollElms = document.querySelectorAll("[data-scroll-animation]");
   scrollElms.forEach((scrollElm) => {
     ScrollTrigger.create({

--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -5,7 +5,7 @@
   const viewport = document.querySelector('meta[name="viewport"]');
   function switchViewport() {
     const value =
-      window.outerWidth > 390
+      globalThis.outerWidth > 390
         ? "width=device-width,initial-scale=1"
         : "width=390";
     if (viewport.getAttribute("content") !== value) {


### PR DESCRIPTION
Linted code, and found several errors in Bone's js. Localhost test successful, so merge to main. 

```
❯ deno lint
error[no-window]: Window is no longer available in Deno
 --> /Users/rcogley/dev/japanactivationcapital.com/src/assets/js/script.js:8:7
  |
8 |       window.outerWidth > 390
  |       ^^^^^^
  = hint: Instead, use `globalThis`

  docs: https://lint.deno.land/rules/no-window


error[no-window]: Window is no longer available in Deno
 --> /Users/rcogley/dev/japanactivationcapital.com/src/assets/js/index.js:8:3
  |
8 |   window.addEventListener("scroll", () => {
  |   ^^^^^^
  = hint: Instead, use `globalThis`

  docs: https://lint.deno.land/rules/no-window


error[no-window-prefix]: For compatibility between the Window context and the Web Workers, calling Web APIs via `window` is disallowed
 --> /Users/rcogley/dev/japanactivationcapital.com/src/assets/js/index.js:8:3
  |
8 |   window.addEventListener("scroll", () => {
  |   ^^^^^^^^^^^^^^^^^^^^^^^
  = hint: Instead, call this API via `self`, `globalThis`, or no extra prefix

  docs: https://lint.deno.land/rules/no-window-prefix


error[no-window]: Window is no longer available in Deno
  --> /Users/rcogley/dev/japanactivationcapital.com/src/assets/js/index.js:29:3
   |
29 |   window.addEventListener("resize", getMvHeight);
   |   ^^^^^^
   = hint: Instead, use `globalThis`

  docs: https://lint.deno.land/rules/no-window


error[no-window-prefix]: For compatibility between the Window context and the Web Workers, calling Web APIs via `window` is disallowed
  --> /Users/rcogley/dev/japanactivationcapital.com/src/assets/js/index.js:29:3
   |
29 |   window.addEventListener("resize", getMvHeight);
   |   ^^^^^^^^^^^^^^^^^^^^^^^
   = hint: Instead, call this API via `self`, `globalThis`, or no extra prefix

  docs: https://lint.deno.land/rules/no-window-prefix


error[no-window]: Window is no longer available in Deno
  --> /Users/rcogley/dev/japanactivationcapital.com/src/assets/js/index.js:85:1
   |
85 | window.addEventListener("load", () => {
   | ^^^^^^
   = hint: Instead, use `globalThis`

  docs: https://lint.deno.land/rules/no-window


error[no-window-prefix]: For compatibility between the Window context and the Web Workers, calling Web APIs via `window` is disallowed
  --> /Users/rcogley/dev/japanactivationcapital.com/src/assets/js/index.js:85:1
   |
85 | window.addEventListener("load", () => {
   | ^^^^^^^^^^^^^^^^^^^^^^^
   = hint: Instead, call this API via `self`, `globalThis`, or no extra prefix

  docs: https://lint.deno.land/rules/no-window-prefix


Found 7 problems (7 fixable via --fix)
```

